### PR TITLE
Simplify dataref structure on fields

### DIFF
--- a/pkg/shared.go
+++ b/pkg/shared.go
@@ -16,17 +16,12 @@ type Dataref struct {
 	Expr        *vm.Program
 	Env         map[string]interface{}
 }
-type Data struct {
-	Dataref_str string `yaml:"dataref_str,omitempty" json:"dataref_str,omitempty"`
-	Dataref     interface{}
-}
 
 type BravoProfile struct {
 	ProfileType string    `yaml:"profile_type,omitempty" json:"profile_type,omitempty"`
 	Condition   string    `yaml:"condition,omitempty" json:"condition,omitempty"`
 	Datarefs    []Dataref `yaml:"datarefs,omitempty" json:"datarefs,omitempty"`
 	Commands    []Command `yaml:"commands,omitempty" json:"commands,omitempty"`
-	Data        []Data    `yaml:"data,omitempty" json:"data,omitempty"`
 	On          func()    `json:"-"`
 	Off         func()    `json:"-"`
 }

--- a/pkg/xplane/datarefs.go
+++ b/pkg/xplane/datarefs.go
@@ -134,17 +134,16 @@ func (s *xplaneService) compileRules(p *pkg.Profile) error {
 		}
 
 		// Modify the fieldValue
-		switch fieldValue.ProfileType {
-		case "led":
-			for j := range fieldValue.Datarefs {
-				dataref := &fieldValue.Datarefs[j] // Get a pointer to the actual element
-				myDataref, found := dataAccess.FindDataRef(dataref.Dataref_str)
-				if !found {
-					s.Logger.Errorf("Dataref not found: %s", dataref.Dataref_str)
-					continue
-				}
-				dataref.Dataref = myDataref
+		for j := range fieldValue.Datarefs {
+			dataref := &fieldValue.Datarefs[j] // Get a pointer to the actual element
+			myDataref, found := dataAccess.FindDataRef(dataref.Dataref_str)
+			if !found {
+				s.Logger.Errorf("Dataref not found: %s", dataref.Dataref_str)
+				continue
+			}
+			dataref.Dataref = myDataref
 
+			if dataref.Operator != "" {
 				datarefType := dataAccess.GetDataRefTypes(myDataref)
 
 				var code string
@@ -177,17 +176,10 @@ func (s *xplaneService) compileRules(p *pkg.Profile) error {
 				dataref.Expr = program
 				dataref.Env = env
 			}
+		}
+
+		if fieldValue.ProfileType == "led" {
 			fieldValue.On, fieldValue.Off = s.assignOnAndOffFuncs(fieldName)
-		case "data":
-			for j := range fieldValue.Data {
-				data := &fieldValue.Data[j] // Get a pointer to the actual element
-				myDataref, found := dataAccess.FindDataRef(data.Dataref_str)
-				if !found {
-					s.Logger.Errorf("Dataref not found: %s", data.Dataref_str)
-					continue
-				}
-				data.Dataref = myDataref
-			}
 		}
 
 		// Assign the modified value back to the struct field


### PR DESCRIPTION
The profile type "led" and "data" don't actually need to be different in the way that they declare or use datarefs. For example, we may wish to have a data-only dataref with a condition, such as the `retractable_gear` dataref...

So I've separated the `profile_type` logic from the way we treat the datarefs. Any profile type can now support an `Expr`.