### PR TITLE
Prevent crash if sections are missing from the plane config file

### DIFF
--- a/pkg/xplane/datarefs.go
+++ b/pkg/xplane/datarefs.go
@@ -27,6 +27,18 @@ func (s *xplaneService) setupDataRefs(airplaneICAO string) {
 			return
 		}
 	}
+	if planeProfile.Metadata == nil {
+		planeProfile.Metadata = &pkg.Metadata{}
+	}
+	if planeProfile.Data == nil {
+		planeProfile.Data = &pkg.Data{}
+	}
+	if planeProfile.Knobs == nil {
+		planeProfile.Knobs = &pkg.Knobs{}
+	}
+	if planeProfile.Leds == nil {
+		planeProfile.Leds = &pkg.Leds{}
+	}
 	err = s.CompileRules(&planeProfile)
 	if err != nil {
 		s.Logger.Errorf("Error compiling rules: %v", err)


### PR DESCRIPTION
We dereference these pointers without checking for nil so this makes that safe. We then seem to safely ignore that these are empty, as it's expected that some leds / data / knobs may be missing.