### PR TITLE
Compile rules fixes

### DIFF
--- a/pkg/xplane/datarefs.go
+++ b/pkg/xplane/datarefs.go
@@ -264,7 +264,6 @@ func (s *xplaneService) compileRules(l *pkg.Leds, d *pkg.Data) error {
 			if !ok {
 				s.Logger.Errorf("Field %s is not of type BravoProfile", fieldName)
 				return fmt.Errorf("Field %s is not of type BravoProfile", fieldName)
-				continue
 			}
 
 			// Modify the fieldValue

--- a/pkg/xplane/datarefs.go
+++ b/pkg/xplane/datarefs.go
@@ -311,7 +311,10 @@ func (s *xplaneService) compileRules(l *pkg.Leds, d *pkg.Data) error {
 					dataref.Expr = program
 					dataref.Env = env
 				}
-				fieldValue.On, fieldValue.Off = s.assignOnAndOffFuncs(fieldName)
+
+				if typ.Name() == "Leds" {
+					fieldValue.On, fieldValue.Off = s.assignOnAndOffFuncs(fieldName)
+				}
 			}
 
 			// Assign the modified value back to the struct field


### PR DESCRIPTION
Don't compile the `Expr` if there isn't an `operator`... as we run `Data` through this as well. It's quite nice that we _could_ get an `Expr` on a `Data` thing... it may that we'd want different types of expressions... maybe we could make the logic for data more complex... anyway, I don't think it's _bad_ that `Data` and `Leds` go through the same `compileRules` and I think perhaps `Knobs` should too.

Also don't try to lookup On/Off on non-Leds.