### PR TITLE
Fix retractable gear to ignore retractable gear if the dataref doesn't exist

### DIFF
--- a/pkg/xplane/datarefs.go
+++ b/pkg/xplane/datarefs.go
@@ -157,19 +157,22 @@ func (s *xplaneService) updateLeds() {
 		if fieldName == "GEAR" {
 			// special case for gear
 			retractable_gear_dataref := s.profile.Data.RETRACTABLE_GEAR.Datarefs[0]
-			retractable_gear_output, retractable_gear_err := expr.Run(retractable_gear_dataref.Expr, retractable_gear_dataref.Env)
-			if retractable_gear_err != nil {
-				s.Logger.Errorf("GEAR - Error running retractable_gear expression: %v", retractable_gear_err)
-				continue
+			if retractable_gear_dataref.Expr != nil {
+				retractable_gear_output, retractable_gear_err := expr.Run(retractable_gear_dataref.Expr, retractable_gear_dataref.Env)
+				if retractable_gear_err != nil {
+					s.Logger.Errorf("GEAR - Error running retractable_gear expression: %v", retractable_gear_err)
+					continue
+				}
+
+				if !retractable_gear_output.(bool) {
+					s.updateGearLEDs([]float32{0, 0, 0})
+					continue
+				}
 			}
 
-			if retractable_gear_output.(bool) {
-				dataref := s.profile.Leds.GEAR.Datarefs[0]
-				output := dataAccess.GetFloatArrayData(dataref.Dataref.(dataAccess.DataRef))
-				s.updateGearLEDs(output)
-			} else {
-				s.updateGearLEDs([]float32{0, 0, 0})
-			}
+			dataref := s.profile.Leds.GEAR.Datarefs[0]
+			output := dataAccess.GetFloatArrayData(dataref.Dataref.(dataAccess.DataRef))
+			s.updateGearLEDs(output)
 			continue
 		}
 


### PR DESCRIPTION
I made a mistake in the first implementation... not every plane will have this dataref. If they don't, then we just assume there's retractable gear now.