### PR TITLE
Load aircraft profile first by its UI name and then by its ICAO

### DIFF
--- a/pkg/xplane/flight_loop.go
+++ b/pkg/xplane/flight_loop.go
@@ -1,7 +1,5 @@
 package xplane
 
-import "github.com/xairline/goplane/xplm/dataAccess"
-
 // flightloop, high freq code!
 func (s *xplaneService) flightLoop(
 	elapsedSinceLastCall,
@@ -12,12 +10,7 @@ func (s *xplaneService) flightLoop(
 
 	if s.profile == nil {
 		s.Logger.Info("Profile is nil, try to load it again")
-		aircraftIACODrf, found := dataAccess.FindDataRef("sim/aircraft/view/acf_ICAO")
-		if !found {
-			s.Logger.Errorf("Failed to find ICAO")
-		}
-		aircraftIACO := dataAccess.GetString(aircraftIACODrf)
-		s.setupDataRefs(aircraftIACO)
+		s.tryLoadProfile()
 	}
 
 	s.updateLeds()

--- a/pkg/xplane/xplane.go
+++ b/pkg/xplane/xplane.go
@@ -28,7 +28,7 @@ type XplaneService interface {
 	// menu handler
 	menuHandler(menuRef interface{}, itemRef interface{})
 	// datarefs
-	setupDataRefs(airplaneICAO string)
+	tryLoadProfile()
 }
 
 type xplaneService struct {


### PR DESCRIPTION
The UI name is more specific, so we try it first. This also gives us the possibility to easily support alternative naming schemes, such as looking in the aircraft folder for a `xa-honeycomb.yaml` file in future.