### PR TITLE
feat: refactor BravoProfile into DataProfile, ConditionProfile, KnobProfile, LEDProfile

### DIFF
--- a/pkg/shared.go
+++ b/pkg/shared.go
@@ -10,9 +10,15 @@ type Command struct {
 type Dataref struct {
 	DatarefStr string `yaml:"dataref_str,omitempty" json:"dataref_str,omitempty"`
 	Dataref    interface{}
+	Index      int `yaml:"index,omitempty" json:"index,omitempty"`
+}
+
+type DatarefCondition struct {
+	DatarefStr string `yaml:"dataref_str,omitempty" json:"dataref_str,omitempty"`
+	Dataref    interface{}
+	Index      int     `yaml:"index,omitempty" json:"index,omitempty"`
 	Operator   string  `yaml:"operator,omitempty" json:"operator,omitempty"`
 	Threshold  float32 `yaml:"threshold,omitempty" json:"threshold,omitempty"`
-	Index      int     `yaml:"index,omitempty" json:"index,omitempty"`
 	Expr       *vm.Program
 	Env        map[string]interface{}
 }
@@ -23,61 +29,81 @@ type Metadata struct {
 	Enabled     bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 }
 
-type BravoProfile struct {
-	Condition string    `yaml:"condition,omitempty" json:"condition,omitempty"`
-	Datarefs  []Dataref `yaml:"datarefs,omitempty" json:"datarefs,omitempty"`
-	Commands  []Command `yaml:"commands,omitempty" json:"commands,omitempty"`
-	On        func()    `json:"-"`
-	Off       func()    `json:"-"`
-	Value     *float32  `yaml:"value,omitempty" json:"value,omitempty"`
+type ConditionProfile struct {
+	Datarefs  []DatarefCondition `yaml:"datarefs,omitempty" json:"datarefs,omitempty"`
+	Condition string             `yaml:"condition,omitempty" json:"condition,omitempty"`
+}
+
+type DatarefProfile struct {
+	Datarefs []Dataref `yaml:"datarefs,omitempty" json:"datarefs,omitempty"`
+}
+
+type LEDProfile struct {
+	ConditionProfile `yaml:",inline"`
+	On               func() `json:"-"`
+	Off              func() `json:"-"`
+}
+
+type DataProfile struct {
+	DatarefProfile `yaml:",inline"`
+	Value          *float32 `yaml:"value,omitempty" json:"value,omitempty"`
+}
+
+type KnobProfile struct {
+	DatarefProfile `yaml:",inline"`
+	Commands       []Command `yaml:"commands,omitempty" json:"commands,omitempty"`
 }
 
 type Knobs struct {
-	AP_HDG BravoProfile `yaml:"ap_hdg,omitempty" json:"ap_hdg,omitempty"`
-	AP_VS  BravoProfile `yaml:"ap_vs,omitempty" json:"ap_vs,omitempty"`
-	AP_ALT BravoProfile `yaml:"ap_alt,omitempty" json:"ap_alt,omitempty"`
-	AP_IAS BravoProfile `yaml:"ap_ias,omitempty" json:"ap_ias,omitempty"`
-	AP_CRS BravoProfile `yaml:"ap_crs,omitempty" json:"ap_crs,omitempty"`
+	AP_HDG KnobProfile `yaml:"ap_hdg,omitempty" json:"ap_hdg,omitempty"`
+	AP_VS  KnobProfile `yaml:"ap_vs,omitempty" json:"ap_vs,omitempty"`
+	AP_ALT KnobProfile `yaml:"ap_alt,omitempty" json:"ap_alt,omitempty"`
+	AP_IAS KnobProfile `yaml:"ap_ias,omitempty" json:"ap_ias,omitempty"`
+	AP_CRS KnobProfile `yaml:"ap_crs,omitempty" json:"ap_crs,omitempty"`
 }
 
 type Leds struct {
-	HDG                BravoProfile `yaml:"hdg,omitempty" json:"hdg,omitempty"`
-	NAV                BravoProfile `yaml:"nav,omitempty" json:"nav,omitempty"`
-	ALT                BravoProfile `yaml:"alt,omitempty" json:"alt,omitempty"`
-	APR                BravoProfile `yaml:"apr,omitempty" json:"apr,omitempty"`
-	VS                 BravoProfile `yaml:"vs,omitempty" json:"vs,omitempty"`
-	AP                 BravoProfile `yaml:"ap,omitempty" json:"ap,omitempty"`
-	IAS                BravoProfile `yaml:"ias,omitempty" json:"ias,omitempty"`
-	REV                BravoProfile `yaml:"rev,omitempty" json:"rev,omitempty"`
-	GEAR               BravoProfile `yaml:"gear,omitempty" json:"gear,omitempty"`
-	MASTER_WARN        BravoProfile `yaml:"master_warn,omitempty" json:"master_warn,omitempty"`
-	MASTER_CAUTION     BravoProfile `yaml:"master_caution,omitempty" json:"master_caution,omitempty"`
-	FIRE               BravoProfile `yaml:"fire,omitempty" json:"fire,omitempty"`
-	OIL_LOW_PRESSURE   BravoProfile `yaml:"oil_low_pressure,omitempty" json:"oil_low_pressure,omitempty"`
-	FUEL_LOW_PRESSURE  BravoProfile `yaml:"fuel_low_pressure,omitempty" json:"fuel_low_pressure,omitempty"`
-	ANTI_ICE           BravoProfile `yaml:"anti_ice,omitempty" json:"anti_ice,omitempty"`
-	ENG_STARTER        BravoProfile `yaml:"eng_starter,omitempty" json:"eng_starter,omitempty"`
-	APU                BravoProfile `yaml:"apu,omitempty" json:"apu,omitempty"`
-	VACUUM             BravoProfile `yaml:"vacuum,omitempty" json:"vacuum,omitempty"`
-	HYDRO_LOW_PRESSURE BravoProfile `yaml:"hydro_low_pressure,omitempty" json:"hydro_low_pressure,omitempty"`
-	AUX_FUEL_PUMP      BravoProfile `yaml:"aux_fuel_pump,omitempty" json:"aux_fuel_pump,omitempty"`
-	PARKING_BRAKE      BravoProfile `yaml:"parking_brake,omitempty" json:"parking_brake,omitempty"`
-	VOLT_LOW           BravoProfile `yaml:"volt_low,omitempty" json:"volt_low,omitempty"`
-	DOORS              BravoProfile `yaml:"doors,omitempty" json:"doors,omitempty"`
+	HDG                LEDProfile `yaml:"hdg,omitempty" json:"hdg,omitempty"`
+	NAV                LEDProfile `yaml:"nav,omitempty" json:"nav,omitempty"`
+	ALT                LEDProfile `yaml:"alt,omitempty" json:"alt,omitempty"`
+	APR                LEDProfile `yaml:"apr,omitempty" json:"apr,omitempty"`
+	VS                 LEDProfile `yaml:"vs,omitempty" json:"vs,omitempty"`
+	AP                 LEDProfile `yaml:"ap,omitempty" json:"ap,omitempty"`
+	IAS                LEDProfile `yaml:"ias,omitempty" json:"ias,omitempty"`
+	REV                LEDProfile `yaml:"rev,omitempty" json:"rev,omitempty"`
+	GEAR               LEDProfile `yaml:"gear,omitempty" json:"gear,omitempty"`
+	MASTER_WARN        LEDProfile `yaml:"master_warn,omitempty" json:"master_warn,omitempty"`
+	MASTER_CAUTION     LEDProfile `yaml:"master_caution,omitempty" json:"master_caution,omitempty"`
+	FIRE               LEDProfile `yaml:"fire,omitempty" json:"fire,omitempty"`
+	OIL_LOW_PRESSURE   LEDProfile `yaml:"oil_low_pressure,omitempty" json:"oil_low_pressure,omitempty"`
+	FUEL_LOW_PRESSURE  LEDProfile `yaml:"fuel_low_pressure,omitempty" json:"fuel_low_pressure,omitempty"`
+	ANTI_ICE           LEDProfile `yaml:"anti_ice,omitempty" json:"anti_ice,omitempty"`
+	ENG_STARTER        LEDProfile `yaml:"eng_starter,omitempty" json:"eng_starter,omitempty"`
+	APU                LEDProfile `yaml:"apu,omitempty" json:"apu,omitempty"`
+	VACUUM             LEDProfile `yaml:"vacuum,omitempty" json:"vacuum,omitempty"`
+	HYDRO_LOW_PRESSURE LEDProfile `yaml:"hydro_low_pressure,omitempty" json:"hydro_low_pressure,omitempty"`
+	AUX_FUEL_PUMP      LEDProfile `yaml:"aux_fuel_pump,omitempty" json:"aux_fuel_pump,omitempty"`
+	PARKING_BRAKE      LEDProfile `yaml:"parking_brake,omitempty" json:"parking_brake,omitempty"`
+	VOLT_LOW           LEDProfile `yaml:"volt_low,omitempty" json:"volt_low,omitempty"`
+	DOORS              LEDProfile `yaml:"doors,omitempty" json:"doors,omitempty"`
 }
 
 type Data struct {
-	BUS_VOLTAGE      BravoProfile `yaml:"bus_voltage,omitempty" json:"bus_voltage,omitempty"`
-	RETRACTABLE_GEAR BravoProfile `yaml:"retractable_gear,omitempty" json:"retractable_gear,omitempty"`
-	AP_STATE         BravoProfile `yaml:"ap_state,omitempty" json:"ap_state,omitempty"`
-	AP_ALT_STEP      BravoProfile `yaml:"ap_alt_step,omitempty" json:"ap_alt_step,omitempty"`
-	AP_VS_STEP       BravoProfile `yaml:"ap_vs_step,omitempty" json:"ap_vs_step,omitempty"`
-	AP_IAS_STEP      BravoProfile `yaml:"ap_ias_step,omitempty" json:"ap_ias_step,omitempty"`
+	AP_STATE    DataProfile `yaml:"ap_state,omitempty" json:"ap_state,omitempty"`
+	AP_ALT_STEP DataProfile `yaml:"ap_alt_step,omitempty" json:"ap_alt_step,omitempty"`
+	AP_VS_STEP  DataProfile `yaml:"ap_vs_step,omitempty" json:"ap_vs_step,omitempty"`
+	AP_IAS_STEP DataProfile `yaml:"ap_ias_step,omitempty" json:"ap_ias_step,omitempty"`
+}
+
+type Conditions struct {
+	BUS_VOLTAGE      ConditionProfile `yaml:"bus_voltage,omitempty" json:"bus_voltage,omitempty"`
+	RETRACTABLE_GEAR ConditionProfile `yaml:"retractable_gear,omitempty" json:"retractable_gear,omitempty"`
 }
 
 type Profile struct {
-	Metadata *Metadata `yaml:"metadata" json:"metadata"`
-	Knobs    *Knobs    `yaml:"knobs,omitempty" json:"knobs,omitempty"`
-	Leds     *Leds     `yaml:"leds,omitempty" json:"leds,omitempty"`
-	Data     *Data     `yaml:"data,omitempty" json:"data,omitempty"`
+	Metadata   *Metadata   `yaml:"metadata" json:"metadata"`
+	Knobs      *Knobs      `yaml:"knobs,omitempty" json:"knobs,omitempty"`
+	Leds       *Leds       `yaml:"leds,omitempty" json:"leds,omitempty"`
+	Data       *Data       `yaml:"data,omitempty" json:"data,omitempty"`
+	Conditions *Conditions `yaml:"conditions,omitempty" json:"conditions,omitempty"`
 }

--- a/pkg/xplane/cmd.go
+++ b/pkg/xplane/cmd.go
@@ -36,13 +36,13 @@ func (s *xplaneService) changeApValue(command utilities.CommandRef, phase utilit
 			s.Logger.Debugf("Decrease: %v, Phase: %v, AP Mode: %s, Multiplier: %.1f", command, phase, s.apSelector, multiplier)
 			direction = -1
 		}
-		var myProfile pkg.BravoProfile
+		var myProfile pkg.KnobProfile
 		var step float64
 		switch s.apSelector {
 		case "ias":
 			myProfile = s.profile.Knobs.AP_IAS
 
-			iasStep, foundIasStep := s.valueOf(&s.profile.Data.AP_IAS_STEP)
+			iasStep, foundIasStep := s.dataValue(&s.profile.Data.AP_IAS_STEP)
 			if foundIasStep {
 				step = iasStep
 			} else {
@@ -51,7 +51,7 @@ func (s *xplaneService) changeApValue(command utilities.CommandRef, phase utilit
 		case "alt":
 			myProfile = s.profile.Knobs.AP_ALT
 
-			altStep, foundAltStep := s.valueOf(&s.profile.Data.AP_ALT_STEP)
+			altStep, foundAltStep := s.dataValue(&s.profile.Data.AP_ALT_STEP)
 			if foundAltStep {
 				step = altStep
 			} else {
@@ -60,7 +60,7 @@ func (s *xplaneService) changeApValue(command utilities.CommandRef, phase utilit
 		case "vs":
 			myProfile = s.profile.Knobs.AP_VS
 
-			vsStep, foundVsStep := s.valueOf(&s.profile.Data.AP_VS_STEP)
+			vsStep, foundVsStep := s.dataValue(&s.profile.Data.AP_VS_STEP)
 			if foundVsStep {
 				step = vsStep
 			} else {
@@ -89,7 +89,7 @@ func (s *xplaneService) changeAPMode(command utilities.CommandRef, phase utiliti
 	return 0
 }
 
-func (s *xplaneService) adjust(myProfile pkg.BravoProfile, direction int, multiplier float64, step float64) {
+func (s *xplaneService) adjust(myProfile pkg.KnobProfile, direction int, multiplier float64, step float64) {
 	if myProfile.Commands != nil {
 		var cmd utilities.CommandRef
 		if direction > 0 {

--- a/profiles/A339.yaml
+++ b/profiles/A339.yaml
@@ -240,7 +240,7 @@ leds:
         operator: ">"
         threshold: 0.01
 
-data:
+conditions:
   retractable_gear:
     datarefs:
       - dataref_str: "sim/aircraft/gear/acf_gear_retract"

--- a/profiles/C172 NG ANALOG.yaml
+++ b/profiles/C172 NG ANALOG.yaml
@@ -171,7 +171,7 @@ leds:
         operator: ">"
         threshold: 0.9
 
-data:
+conditions:
   bus_voltage:
     datarefs:
       - dataref_str: "sim/cockpit2/electrical/bus_volts"
@@ -184,6 +184,7 @@ data:
         operator: "!="
         threshold: 0
 
+data:
   ap_vs_step:
     datarefs:
       - dataref_str: "sim/aircraft/autopilot/vvi_step_ft"

--- a/profiles/C172.yaml
+++ b/profiles/C172.yaml
@@ -169,7 +169,7 @@ leds:
         operator: ">"
         threshold: 0.9
 
-data:
+conditions:
   bus_voltage:
     datarefs:
       - dataref_str: "sim/cockpit2/electrical/bus_volts"
@@ -182,6 +182,7 @@ data:
         operator: "!="
         threshold: 0
 
+data:
   ap_vs_step:
     datarefs:
       - dataref_str: "sim/aircraft/autopilot/vvi_step_ft"

--- a/profiles/MD11.yaml
+++ b/profiles/MD11.yaml
@@ -238,7 +238,7 @@ leds:
         operator: ">"
         threshold: 0.01
 
-data:
+conditions:
   retractable_gear:
     datarefs:
       - dataref_str: "sim/aircraft/gear/acf_gear_retract"


### PR DESCRIPTION
OK, I know this is a big one. I reckon start with what I think is the magic...

* `cmd.go` now references `KnobProfile` and has the `Commands`, while no others do
* The `BUS_VOLTAGE` logic now looks like this:
  ```
  	busVoltage, busVoltageOK := s.evaluateCondition((&s.profile.Conditions.BUS_VOLTAGE))
	if busVoltageOK && !busVoltage {
		honeycomb.AllOff()
		return
	}
  ```
* Similarly the `RETRACTABLE_GEAR` logic now looks like this:
  ```
  			retractableGear, retractableGearOK := s.evaluateCondition(&s.profile.Conditions.RETRACTABLE_GEAR)
			if retractableGearOK && !retractableGear {
				s.updateGearLEDs([]float32{0, 0, 0})
				continue
			}
  ```
* ... and all of that is type-safe... we guarantee having valid data of the right sort of data now, and we can validate it when the profile loads
* Similarly the logic later on in `updateLeds` also uses the new `s.evaluateCondition`

I had to really chop up the `compileRules` stuff... it's recognisable but there's a lot changed. I tried to introduce some sort of generic iteration over the structs... and some reuse of the common parts of the different `*Profile` types. See what you think in there. You may well want to do a second pass over this.

I have updated all of the YAML profiles (which as you'll see was trivial) and I expect they'll just work.

The error handling on loading a profile is interesting... we can't just not set the profile, as then we enter into a loop of loading profiles each frame. So I just let the profile be. Maybe when we get more sophisticated we'd show an alert with some error messages? Anyway... that's all in the `setupDatarefs` method now so easy to improve.